### PR TITLE
Add Lecture Query API

### DIFF
--- a/backend/controllers/lectureController.go
+++ b/backend/controllers/lectureController.go
@@ -3,10 +3,10 @@ package controllers
 import (
 	"net/http"
 	"strconv"
+	"tms-server/models"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
-	"tms-server/models"
 )
 
 func FilteredLectures(db *gorm.DB) gin.HandlerFunc {
@@ -39,6 +39,65 @@ func FilteredLectures(db *gorm.DB) gin.HandlerFunc {
 			} else {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid course_id parameter"})
 				return
+			}
+		}
+
+		if err := query.Find(&lectures).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusOK, lectures)
+	}
+}
+
+// Probably combine this with above, but keeping it for backward compatibility
+// Having general way to query Lectures, and any filters. (this also includes section)
+func QueryLectures(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var lectures []models.Lecture
+
+		courseIDStr := c.Query("course_id")
+		yearStr := c.Query("year")
+		semesterStr := c.Query("semester")
+		facultyIDStr := c.Query("faculty_id")
+		roomIDStr := c.Query("room_id")
+
+		query := db.Preload("Subject").Preload("Faculty").Preload("Batch").Preload("Room")
+
+		if semesterStr != "" {
+			if semester, err := strconv.Atoi(semesterStr); err == nil {
+				query = query.Where("semester = ?", semester)
+			}
+		}
+
+		if facultyIDStr != "" {
+			if facultyID, err := strconv.Atoi(facultyIDStr); err == nil {
+				query = query.Where("faculty_id = ?", facultyID)
+			}
+		}
+
+		if roomIDStr != "" {
+			if roomID, err := strconv.Atoi(roomIDStr); err == nil {
+				query = query.Where("room_id = ?", roomID)
+			}
+		}
+
+		if courseIDStr != "" && yearStr != "" {
+			courseID, err1 := strconv.Atoi(courseIDStr)
+			year, err2 := strconv.Atoi(yearStr)
+
+			if err1 == nil && err2 == nil {
+				var batch models.Batch
+				if err := db.Where("course_id = ? AND year = ?", courseID, year).First(&batch).Error; err == nil {
+					query = query.Where("batch_id = ?", batch.ID)
+				} else if err == gorm.ErrRecordNotFound {
+					c.JSON(http.StatusNotFound, gin.H{"error": "Batch not found"})
+					return
+				} else {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+					return
+				}
 			}
 		}
 

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -53,6 +53,7 @@ func registerFacultyRoutes(r *gin.RouterGroup, db *gorm.DB) {
 	r.GET("/batch/:id", controllers.Get[models.Batch](db))
 
 	r.GET("/lecture", controllers.FilteredLectures(db))
+	r.GET("/lecture/query", controllers.QueryLectures(db))
 	r.GET("/lecture/:id", controllers.Get[models.Lecture](db))
 
 	r.GET("/session", controllers.All[models.Session](db))


### PR DESCRIPTION
### Add Lecture Query API

**Endpoint:**
`GET /api/v1/lecture/query`

**Query Params (all optional):**

* `course_id`: int
* `year`: int
* `semester`: int
* `faculty_id`: int
* `room_id`: int

If `course_id` and `year` are provided, they're mapped to `batch_id`.

**Example:**
`/api/v1/lecture/query?course_id=3&year=2023&semester=4&faculty_id=7`

Returns lectures matching the filters with related data (Subject, Faculty, Batch, Room) preloaded.
